### PR TITLE
0.1.1-alpha Patch

### DIFF
--- a/src/discMapper.xml
+++ b/src/discMapper.xml
@@ -3164,7 +3164,7 @@ registerAnonymousEventHandler("onPrompt", "map.eventHandler")
 		</Script>
 	</ScriptPackage>
 	<KeyPackage />
-	<VariablePackage>
-		<HiddenVariables />
-	</VariablePackage>
+	<HelpPackage>
+		<helpURL></helpURL>
+	</HelpPackage>
 </MudletPackage>

--- a/src/discMapper.xml
+++ b/src/discMapper.xml
@@ -42,7 +42,7 @@
 				</regexCodePropertyList>
 			</Trigger>
 			<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
-				<name>Detect room exists</name>
+				<name>Exit Detection</name>
 				<script>local realexits = {}
 for raw_exit in string.gmatch(matches[2], "%a+") do
   local exit = mmp.anytoshort(raw_exit)

--- a/src/discMapper.xml
+++ b/src/discMapper.xml
@@ -18,7 +18,7 @@
 			<regexCodeList />
 			<regexCodePropertyList />
 			<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
-				<name>Room fail</name>
+				<name>Move Fail</name>
 				<script>raiseEvent("onMoveFail")</script>
 				<triggerType>0</triggerType>
 				<conditonLineDelta>0</conditonLineDelta>
@@ -32,15 +32,13 @@
 				<colorTriggerBgColor>#000000</colorTriggerBgColor>
 				<regexCodeList>
 					<string>^That doesn't work\.$</string>
-					<string>^What?$</string>
+					<string>^What\?$</string>
 					<string>^Try something else\.$</string>
-					<string>What?</string>
 				</regexCodeList>
 				<regexCodePropertyList>
 					<integer>1</integer>
 					<integer>1</integer>
 					<integer>1</integer>
-					<integer>3</integer>
 				</regexCodePropertyList>
 			</Trigger>
 			<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">

--- a/src/discMapper.xml
+++ b/src/discMapper.xml
@@ -45,7 +45,7 @@
 				<name>Exit Detection</name>
 				<script>local realexits = {}
 for raw_exit in string.gmatch(matches[2], "%a+") do
-  local exit = mmp.anytoshort(raw_exit)
+  local exit = map.get_short_exit(raw_exit)
   if exit then
     realexits[#realexits + 1] = exit
   end


### PR DESCRIPTION
- [Enhancement] Renames the module `discMapper.xml` so updating filename not required as we progress.
- [Bugfixes]
  - Properly escape `Room fail` trigger regex special character and removed now redundant exact match trigger
  - Fix typos in trigger names
  - Fixed call to non-existent IRE Mapper function for exit shortening that was throwing a Lua error when fired