### PR TITLE
0.1.2-alpha

### DIFF
--- a/src/discMapper.xml
+++ b/src/discMapper.xml
@@ -761,7 +761,7 @@ end</script>
 		<Script isActive="yes" isFolder="no">
 			<name>discMapper</name>
 			<packageName></packageName>
-			<script>-- discMapper v0.1.0
+			<script>-- discMapper v0.1.2
 -- forked from Jor'Mox's Generic Map Script 11/07/2018 version dated 10/20/2019 in Mudlet/src
 local version = "2.0.16" -- Generic Map Script version
 
@@ -2889,7 +2889,7 @@ local function name_search()
 end
 
 local function handle_exits(exits)
-    local room = map.prompt.room or name_search()
+    local room = gmcp.room.info.name
     room = map.sanitizeRoomName(room)
     exits = map.prompt.exits or exits
     exits = string.lower(exits)


### PR DESCRIPTION
This resolves the second of the two immediate errors we found would occur upon loading the script to a new profile. As shown below, room name is being successfully passed to the mapper by GMCP and the exits are correctly detected by text matching trigger.

![image](https://user-images.githubusercontent.com/1428343/85701823-a6509200-b692-11ea-9af0-5295a4def202.png)

I suspect the next obstacle will be where `map basics` doesn't recognize that room name and exits are being detected via GMCP and then will not allow `start mapping` to be called successfully.

Closes #41 