### PR TITLE
feat(update): Add Automated Updates

### DIFF
--- a/src/discMapper.xml
+++ b/src/discMapper.xml
@@ -2993,7 +2993,7 @@ end
 
 local function update_version()
     downloading = false
-    local path = profilePath .. "/map downloads/generic_mapper.xml"
+    local path = profilePath .. "/map downloads/discMapper.xml"
     disableAlias("Map Update Alias")
     uninstallPackage("generic_mapper")
     installPackage(path)

--- a/src/discMapper.xml
+++ b/src/discMapper.xml
@@ -3001,7 +3001,7 @@ local function update_version()
 end
 
 function map.updateVersion()
-    local path, file = profilePath .. "/map downloads", "/generic_mapper.xml"
+    local path, file = profilePath .. "/map downloads", "/discMapper.xml"
     downloading = true
     downloadFile(path .. file, map.configs.download_path .. file)
 end

--- a/src/discMapper.xml
+++ b/src/discMapper.xml
@@ -2997,7 +2997,7 @@ local function update_version()
     disableAlias("Map Update Alias")
     uninstallPackage("discMapper")
     installPackage(path)
-    map.echo("Generic Mapping Script updated successfully.")
+    map.echo("discMapper updated successfully.")
 end
 
 function map.updateVersion()

--- a/src/discMapper.xml
+++ b/src/discMapper.xml
@@ -2995,7 +2995,7 @@ local function update_version()
     downloading = false
     local path = profilePath .. "/map downloads/discMapper.xml"
     disableAlias("Map Update Alias")
-    uninstallPackage("generic_mapper")
+    uninstallPackage("discMapper")
     installPackage(path)
     map.echo("Generic Mapping Script updated successfully.")
 end

--- a/src/discMapper.xml
+++ b/src/discMapper.xml
@@ -1367,7 +1367,7 @@ map.defaults = {
         northwest = 'northwest', up = 'up', down = 'down',
     },
     debug = false,
-    download_path = "https://raw.githubusercontent.com/Mudlet/Mudlet/development/src/mudlet-lua/lua/generic-mapper",
+    download_path = "https://github.com/iLPdev/discMapper/raw/main/src/discMapper.xml",
 }
 
 local move_queue, lines = {}, {}

--- a/src/discMapper.xml
+++ b/src/discMapper.xml
@@ -1400,10 +1400,10 @@ local function config()
         stubmap[count] = v[1]
         stubmap[v[1]] = count
     end
-    -- update to the current download path
-    if map.configs.download_path == "https://raw.githubusercontent.com/JorMox/Mudlet/development/src/mudlet-lua/lua/generic-mapper" then
-        map.configs.download_path = "https://raw.githubusercontent.com/Mudlet/Mudlet/development/src/mudlet-lua/lua/generic-mapper"
-    end
+    -- -- update to the current download path
+    -- if map.configs.download_path == "https://raw.githubusercontent.com/JorMox/Mudlet/development/src/mudlet-lua/lua/generic-mapper" or then
+        -- map.configs.download_path = "https://raw.githubusercontent.com/Mudlet/Mudlet/development/src/mudlet-lua/lua/generic-mapper"
+    -- end
 
     -- setup metatable to store sensitive values
     local protected = {"mapping", "currentRoom", "currentName", "currentExits", "currentArea",


### PR DESCRIPTION
discMapper will now intermittently compare the local version to the version on `main` branch. If the local version is outdated, the script will download and install the latest version (after uninstalling the outdated package). The autoupdate will then announce completion of the process, if successful.