### PR TITLE
Revert "fix: Release hotfix v0.4.2-beta"

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Version numbering approximates the [Semantic Versioning](http://semver.org) appr
 
 - **Project State**: discMapper is under active development. The application can be used, but may be unstable. We are in need of beta testing prior to moving forward with the v1.0.0 release.
 
-- **Current Release**: v0.4.2-beta hotfix is a patch that restores stashed commits that I left on local when I released v0.4.1-beta (I really need to standardize a release checklist for precisely these sort of reasons).
+- **Current Release**: v0.4.1-beta patches a missing event handler for the room styling feature set (thanks @Vadi2!) and fixes redundant initialization bug when installed as a module.
 
 **[^Top](#table-of-contents)**
 

--- a/src/discMapper.xml
+++ b/src/discMapper.xml
@@ -735,7 +735,7 @@ end</script>
 			<packageName></packageName>
 			<script>-- discMapper
             
-local version = "0.4.2-beta"
+local version = "0.4.1-beta"
 
     -- look into options for non-standard door usage for speedwalk
     -- come up with aliases to set translations and custom exits, add appropriate help info


### PR DESCRIPTION
Reverts iLPdev/discMapper#109

I thought I messed up, but these were intentionally stashed changes for 0.5.0 on the feature/kefke-colormatch branch! I clearly need to get some sleep.